### PR TITLE
Made pausing a paused queue return a success rather than a failure.

### DIFF
--- a/Tests/Integration/PauseTest.php
+++ b/Tests/Integration/PauseTest.php
@@ -62,7 +62,7 @@ class PauseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, Resque::size('upgrade:test'));
 
         // Pause paused queue
-        $this->assertFalse($this->pauser->pause('upgrade:test'));
+        $this->assertTrue($this->pauser->pause('upgrade:test'));
 
         // Pause non-existent queue
         $this->assertTrue($this->pauser->pause('upgrade:test2'));

--- a/src/JobPauser.php
+++ b/src/JobPauser.php
@@ -35,7 +35,7 @@ class JobPauser
      */
     public function pause($queue)
     {
-        return $this->redis->sadd(self::$pausedSetName, $queue);
+        return $this->isPaused($queue) || $this->redis->sadd(self::$pausedSetName, $queue);
     }
 
     /**
@@ -46,10 +46,7 @@ class JobPauser
      */
     public function resume($queue)
     {
-        if (!$this->isPaused($queue)) {
-            return true;
-        }
-        return $this->redis->srem(self::$pausedSetName, $queue);
+        return !$this->isPaused($queue) || $this->redis->srem(self::$pausedSetName, $queue);
     }
 
     /**


### PR DESCRIPTION
It now matches resume. Apparently I missed a spot :(
@bigcommerce/tools @lord2800 